### PR TITLE
Fix winner display in vegas settlement

### DIFF
--- a/peel-eat-golf-scorecards/js/core/main.js
+++ b/peel-eat-golf-scorecards/js/core/main.js
@@ -287,11 +287,11 @@ function updateVegas() {
     } else if (diff > 0) {
         settlementText = `Team 2 owes Team 1 ${Math.abs(diff)} points`;
         settlementAmount = Math.abs(diff);
-        winner = 'Team 2';
+        winner = 'Team 1';
     } else {
         settlementText = `Team 1 owes Team 2 ${Math.abs(diff)} points`;
         settlementAmount = Math.abs(diff);
-        winner = 'Team 1';
+        winner = 'Team 2';
     }
     
     currentRoundState.settlement = {


### PR DESCRIPTION
## Summary
- correct winner assignment for vegas settlements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840aec8400c8331969bb05aa3d162f6